### PR TITLE
Allow deploying multiple tiles on multiple cf instances info

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -137,7 +137,7 @@ The proxy environment variables set for the AppDynamics Nozzle and the AppDynami
 
     ![AppDynamics KPI Dashboard Restart button](./images/pcf-dashboard-restart-app-ui.png)
 
-## <a id='overide-nozzle-ops-manager'></a> Advanced Configuration of an AppDynamics Application
+## <a id='overide-nozzle-ops-manager'></a> Advanced Configuration
 
 To use AppDynamics Controllers version 4.4.x, you must first create an instance of an application before deploying the AppD Platform Montioring Tile.
 You can do this using either the Apps Manager or from the Cloud Foundry Command Line Interface (cf CLI). The app name argument is optional, so that they match with your existing application.
@@ -161,13 +161,10 @@ You must select a `Go SDK` tier, but the tier id is not necessary for Advanced C
 
 1. In the Installation Dashboard, click **Apply Changes** and wait for the changes to be applied.
 
-### Deploy multiple tiles on multiple cf instances to the same AppDynamics controller
+### <a id='deploy-multiple-tiles-on-multiple-instances'></a> Deploying Multiple Tiles on Multiple Cloud Foundry Instances to a Single AppDynamics Controller
 
-In cases where you want to deploy multiple AppDynamics tiles on multiple CF foundations and use a single AppD controller, you can now record these metrics under two different tiers.
+You may wish to deploy multiple AppDynamics service broker tiles on to multiple Cloud Foundry instances, using a single AppDynamics Controller.
+The metrics corresponding to each of the cloud foundry instances are recorded under tier names which defaults to the system domain's value of the Cloud Foundry deployment.
+For example: `sys.pie-multi-az-blue.cfplatformeng.com`
 
-To implement this change, review these tile install and reinstall use-case scenarios:
-
-1. Customers who have installed a previous version of the tile and are using the default value "appd-nozzle-tier", can continue to use the default value.
-1. Customers who have installed a previous version of the tile and are not using default value, can continue to use whatever value they have specified for the tier-name.
-1. Customers who do a new installation have the tier-name set to the CF system domain's default value. For example: `sys.pie-multi-az-blue.cfplatformeng.com`
-1. Customers who do a new installation with a custom value, have a tier-name with a custom value for tier. 
+In addtion, you can overwrite the tier name with a custom value by filling in the **Nozzle Tier Name** field as mentioned in the section above.

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -160,3 +160,14 @@ You must select a `Go SDK` tier, but the tier id is not necessary for Advanced C
 
 
 1. In the Installation Dashboard, click **Apply Changes** and wait for the changes to be applied.
+
+### Deploy multiple tiles on multiple cf instances to the same AppDynamics controller
+
+In cases where you want to deploy multiple AppDynamics tiles on multiple CF foundations and use a single AppD controller, you can now record these metrics under two different tiers.
+
+To implement this change, review these tile install and reinstall use-case scenarios:
+
+1. Customers who have installed a previous version of the tile and are using the default value "appd-nozzle-tier", can continue to use the default value.
+1. Customers who have installed a previous version of the tile and are not using default value, can continue to use whatever value they have specified for the tier-name.
+1. Customers who do a new installation have the tier-name set to the CF system domain's default value. For example: `sys.pie-multi-az-blue.cfplatformeng.com`
+1. Customers who do a new installation with a custom value, have a tier-name with a custom value for tier. 


### PR DESCRIPTION
Added information to: appdynamics-platform/installing.html, may need an h2 headline?
Wasn't sure if this information should live at the bottom of this appdynamics-platform/using.html instead?
